### PR TITLE
OPENIG-9122 Expose the CachingJwkSetService purposes used to obtain secrets, for use by client code

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -1,8 +1,7 @@
 {
   "properties": {
     "security": {
-      "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|true}"},
-      "tlsTransportCertSecretId": "tls.cert.secret.id"
+      "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|true}"}
     },
     "oauth2": {
       "tokenEndpointAuthMethodsSupported": {
@@ -226,8 +225,7 @@
       "config": {
         "endpointHandler": "OBClientHandler",
         "cacheMaxSize": 500,
-        "cacheTimeout": "24 hours",
-        "tlsTransportCertSecretId": "&{security.tlsTransportCertSecretId}"
+        "cacheTimeout": "24 hours"
       }
     },
     {
@@ -302,10 +300,7 @@
     },
     {
       "name": "TransportCertValidator",
-      "type": "DefaultTransportCertValidator",
-      "config": {
-        "transportCertSecretId": "&{security.tlsTransportCertSecretId}"
-      }
+      "type": "DefaultTransportCertValidator"
     },
     {
       "name": "IdmService",

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -1,8 +1,7 @@
 {
   "properties": {
     "security": {
-      "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|true}"},
-      "tlsTransportCertSecretId": "tls.cert.secret.id"
+      "enableTestTrustedDirectory": {"$bool": "&{ig.test.directory.enabled|true}"}
     },
     "oauth2": {
       "tokenEndpointAuthMethodsSupported": {
@@ -214,8 +213,7 @@
       "config": {
         "endpointHandler": "OBClientHandler",
         "cacheMaxSize": 500,
-        "cacheTimeout": "24 hours",
-        "tlsTransportCertSecretId": "&{security.tlsTransportCertSecretId}"
+        "cacheTimeout": "24 hours"
       }
     },
     {
@@ -290,10 +288,7 @@
     },
     {
       "name": "TransportCertValidator",
-      "type": "DefaultTransportCertValidator",
-      "config": {
-        "transportCertSecretId": "&{security.tlsTransportCertSecretId}"
-      }
+      "type": "DefaultTransportCertValidator"
     },
     {
       "name": "IdmService",

--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
@@ -65,7 +65,6 @@
             "file": "ProcessRegistration.groovy",
             "args": {
               "jwkSetService": "${heap['JwkSetService']}",
-              "tlsTransportCertSecretId": "&{security.tlsTransportCertSecretId}",
               "allowIgIssuedTestCerts": "${security.enableTestTrustedDirectory}",
               "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",
               "trustedDirectoryService": "${heap['TrustedDirectoryService']}"

--- a/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
@@ -1,6 +1,6 @@
 import static org.forgerock.http.protocol.Response.newResponsePromise
 import static org.forgerock.json.JsonValue.json
-import static org.forgerock.secrets.Purpose.purpose
+import static org.forgerock.openig.fapi.jwks.JwkSetServicePurposes.transportPurpose
 import static org.forgerock.util.promise.Promises.newExceptionPromise
 import static org.forgerock.util.promise.Promises.newResultPromise
 
@@ -354,8 +354,7 @@ private Promise<Void, NoSuchSecretException> testTlsClientCertInJwksUri(X509Cert
     // TODO: This should be refactored to use the DefaultTransportCertValidator
     return jwkSetService.getJwkSetSecretStore(jwksUri)
                         .thenAsync(jwkSetSecretStore -> {
-                            Purpose<VerificationKey> tlsPurpose =
-                                    purpose(tlsTransportCertSecretId, VerificationKey.class)
+                            Purpose<VerificationKey> tlsPurpose = transportPurpose()
                                             .withConstraints(matchesX509Cert(tlsClientCert))
                             return jwkSetSecretStore.getValid(tlsPurpose)
                                     .then(secrets -> {

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/ResponsePathTransportCertValidationFilterTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/mtls/ResponsePathTransportCertValidationFilterTest.java
@@ -21,13 +21,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.forgerock.json.JsonValue.field;
 import static org.forgerock.json.JsonValue.json;
 import static org.forgerock.json.JsonValue.object;
-import static org.forgerock.secrets.Purpose.purpose;
 import static org.forgerock.util.promise.Promises.newExceptionPromise;
 import static org.forgerock.util.promise.Promises.newResultPromise;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -52,9 +50,7 @@ import org.forgerock.openig.fapi.context.FapiContext;
 import org.forgerock.openig.heap.HeapImpl;
 import org.forgerock.openig.heap.Heaplet;
 import org.forgerock.openig.heap.Name;
-import org.forgerock.secrets.Purpose;
 import org.forgerock.secrets.jwkset.JwkSetSecretStore;
-import org.forgerock.secrets.keys.VerificationKey;
 import org.forgerock.services.context.AttributesContext;
 import org.forgerock.services.context.RootContext;
 import org.forgerock.util.Options;
@@ -83,9 +79,6 @@ public class ResponsePathTransportCertValidationFilterTest {
 
     // The transport cert JWK's keyUse, and related purpose
     private static final String TRANSPORT_CERT_KEY_USE = "tls";
-    private static final String TRANSPORT_CERT_LABEL = "tls";
-    private static final Purpose<VerificationKey> TRANSPORT_CERT_PURPOSE =
-            purpose(TRANSPORT_CERT_LABEL, VerificationKey.class);
 
     // It's easier to use a real JwkSetSecretStore
     private static JwkSetSecretStore jwkSetSecretStore;
@@ -274,7 +267,7 @@ public class ResponsePathTransportCertValidationFilterTest {
             // ... and heap
             Heaplet heaplet = heapletClass.getDeclaredConstructor().newInstance();
             HeapImpl heap = new HeapImpl(Name.of("heap"));
-            heap.put("transportCertValidator", new DefaultTransportCertValidator(TRANSPORT_CERT_PURPOSE));
+            heap.put("transportCertValidator", new DefaultTransportCertValidator());
             // ... and ResponsePathTransportCertValidationFilter config
             JsonValue config = json(object(field("trustedDirectoryService", "trustedDirectoryService"),
                                            field("jwkSetService", "jwkSetService"),


### PR DESCRIPTION
Objective:
Just expose the purposes used for use by client code, so as to reduce config and risk or config error.
Now client code can get the appropriate Purpose to use to obtain the specific key, rather than risk supplying the wrong one (via docs, etc).