### PR TITLE
1676: Split IG into AS/RS and deploy to Devenvs

### DIFF
--- a/_infra/helm/secure-api-gateway-fapi-pep-as/templates/configmap.yaml
+++ b/_infra/helm/secure-api-gateway-fapi-pep-as/templates/configmap.yaml
@@ -23,6 +23,8 @@ data:
   CERT_ISSUER: {{ .Values.configmap.certIssuer }}
   # Connection settings for the IG hosted data repo
   GATEWAY_DATA_REPO_URI: {{ .Values.configmap.gatewayDataRepoURI }}
+  # This should be removed when AM bug is fixed
+  IG_OB_ASPSP_SIGNING_KID: {{ .Values.configmap.igOBASPSPSigningKid }}
   # Wherever to use additional TTD other than OB
   IG_TEST_DIRECTORY_ENABLED: {{ .Values.configmap.igTestDirectoryEnabled | quote }}
   # Where to store the IG Truststore

--- a/_infra/helm/secure-api-gateway-fapi-pep-as/values.yaml
+++ b/_infra/helm/secure-api-gateway-fapi-pep-as/values.yaml
@@ -10,6 +10,7 @@ configmap:
   cloudType: "CDK"
   gatewayDataRepoURI: "http://ig:80"
   identityPlatformFQDN: "iam.dev-cdk-core.forgerock.financial"
+  igOBASPSPSigningKid: "sU72Qz8tTtH9W6EoG-vhEYiQTJc"
   igTestDirectoryEnabled: "true"
   igTruststorePath: "/secrets/truststore/igtruststore"
   sapigType: "core"

--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -329,6 +329,17 @@
       "config": {
         "idmService": "IdmService"
       }
+    },
+    {
+      "name": "ObJwtReSigner",
+      "type": "JwtReSigner",
+      "config": {
+        "verificationSecretsProvider": "SecretsProvider-AmJWK",
+        "verificationSecretId": "any.value.in.regex.format",
+        "signingKeyId": "&{ig.ob.aspsp.signing.kid}",
+        "signingSecretsProvider": "SecretsProvider-ASPSP",
+        "signingKeySecretId": "jwt.signer"
+      }
     }
   ],
   "monitor": true

--- a/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/prod/config/config.json
@@ -317,6 +317,17 @@
       "config": {
         "idmService": "IdmService"
       }
+    },
+    {
+      "name": "ObJwtReSigner",
+      "type": "JwtReSigner",
+      "config": {
+        "verificationSecretsProvider": "SecretsProvider-AmJWK",
+        "verificationSecretId": "any.value.in.regex.format",
+        "signingKeyId": "&{ig.ob.aspsp.signing.kid}",
+        "signingSecretsProvider": "SecretsProvider-ASPSP",
+        "signingKeySecretId": "jwt.signer"
+      }
     }
   ],
   "monitor": true

--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/23-as-authorize-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/23-as-authorize-endpoint.json
@@ -51,6 +51,14 @@
           "config": {
             "apiClientService": "IdmApiClientService"
           }
+        },
+        {
+          "name": "AuthorizeResponseJwtReSignFilter",
+          "type": "AuthorizeResponseJwtReSignFilter",
+          "comment": "Re-sign the authorize response data (id_token and/or JARM response) returned by AM to fix OB keyId issue",
+          "config": {
+            "jwtReSigner": "ObJwtReSigner"
+          }
         }
       ],
       "handler": "FRReverseProxyHandler"


### PR DESCRIPTION
This is temporary - once an AM bug is fixed this can be removed
Add in AuthorizeResponseJwtReSignFilter to the 23-as-authorize-endpoint.json for using fapi-pep-as in OB

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1676