### PR TITLE
OPENIG-9209 Update client certificate configuration

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/20-as-dcr-endpoint.json
@@ -34,7 +34,7 @@
           "name": "FapiContextInitializerFilter",
           "type": "FapiContextInitializerFilter",
           "config": {
-            "tlsCertificateHeaderName": "ssl-client-cert"
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}"
           }
         },
         {

--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/21-as-token-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/21-as-token-endpoint.json
@@ -40,7 +40,7 @@
           "name": "FapiContextInitializerFilter",
           "type": "FapiContextInitializerFilter",
           "config": {
-            "tlsCertificateHeaderName": "ssl-client-cert"
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}"
           }
         },
         {

--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/22-as-par-endpoint.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/22-as-par-endpoint.json
@@ -36,7 +36,7 @@
           "name": "FapiContextInitializerFilter",
           "type": "FapiContextInitializerFilter",
           "config": {
-            "tlsCertificateHeaderName": "ssl-client-cert"
+            "clientCertificate": "${pemCertificate(urlDecode(request.headers['ssl-client-cert'][0]))}"
           }
         },
         {


### PR DESCRIPTION
Due to OPENIN-9209 changes, the configuration to retrieve the client certificate must be updated to use the new Expression.