### PR TITLE
1686: Fix missing FapiContext exception

### DIFF
--- a/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
+++ b/secure-api-gateway-ig-extensions/src/main/java/com/forgerock/sapi/gateway/metrics/RouteMetricsFilter.java
@@ -131,7 +131,7 @@ public class RouteMetricsFilter implements Filter {
     }
 
     private static ApiClient getApiClientFromContext(Context context) {
-        return context.asContext(FapiContext.class).getApiClient();
+        return context.as(FapiContext.class).map(FapiContext::getApiClient).orElse(null);
     }
 
     private Promise<Map<String, Object>, NeverThrowsException> getRouteMetricsContext(Context context, Request request) {


### PR DESCRIPTION
While fixing another issue there were a lot of errors logged stating;
`Failed to publish metrics due to exception`

This PR fixes that code by making the api client optional again, because depending on the request is not always present. 

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1686