### PR TITLE
1687: use new FapiContext to retrieve ApiClient

### DIFF
--- a/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
+++ b/config/7.3.0/fapi1part2adv/ig/scripts/groovy/ProcessRegistration.groovy
@@ -211,7 +211,7 @@ switch (method.toUpperCase()) {
         rewriteUriToAccessExistingAmRegistration()
         return next.handle(context, request)
                 .thenAsync(response -> {
-                    var apiClient = attributes.apiClient
+                    var apiClient =  contexts.fapi.getApiClient()
                     if (apiClient && apiClient.softwareStatementAssertion) {
                         return addSoftwareStatementToResponse(response, apiClient.softwareStatementAssertion)
                     }

--- a/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/scripts/ProcessRegistrationTest.java
+++ b/secure-api-gateway-ig-extensions/src/test/java/com/forgerock/sapi/gateway/scripts/ProcessRegistrationTest.java
@@ -649,13 +649,13 @@ class ProcessRegistrationTest extends AbstractScriptTest {
             // Given
             when(ssa.build()).thenReturn(SSA_AS_JWT_STR);
             Request request = new Request().setMethod("GET").setUri(REQUEST_URI);
+            fapiContext.asContext(FapiContext.class).setApiClient(apiClient(ssa));
             when(next.handle(fapiContext, request))
                     .thenReturn(newResponsePromise(new Response(OK).setEntity(json(object()))));
             // ... filter and context
             JsonValue config = validProcessRegistrationConfig();
             Filter filter = (Filter) new ScriptableFilter.Heaplet()
                     .create(Name.of("ProcessRegistration"), config, getHeap());
-            fapiContext.asContext(AttributesContext.class).getAttributes().put("apiClient", apiClient(ssa));
             // When
             final Response response = filter.filter(fapiContext, request, next).get();
             // Then - request apiClientId manipulated


### PR DESCRIPTION
ApiClient has been migrated to the new FapiContext, so ProcessRegistrationProcess needs to use the new location.

https://github.com/SecureApiGateway/SecureApiGateway/issues/1687