### PR TITLE
1696: authorization_endpoint will be on mTLS endpoint

### DIFF
--- a/_infra/helm/secure-api-gateway-fapi-pep-as/templates/ingress.yaml
+++ b/_infra/helm/secure-api-gateway-fapi-pep-as/templates/ingress.yaml
@@ -42,6 +42,13 @@ spec:
                   number: 80
             path: /am/oauth2/realms/root/realms/{{ .Values.configmap.amRealm }}/par
             pathType: Prefix
+          - backend:
+              service:
+                name: {{ .Chart.Name }}
+                port:
+                  number: 80
+            path: /am/oauth2/realms/root/realms/{{ .Values.configmap.amRealm }}/authorize
+            pathType: Prefix
   tls:
     - hosts:
         - {{ .Values.ingress.asMtls.tls.host }}

--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -209,8 +209,7 @@
       "type": "TrustedDirectoryService",
       "config": {
         "trustedDirectories": [
-          "OpenBankingTestDirectory",
-          "SecureAPIGatewayTestDirectory"
+          "OpenBankingTestDirectory"
         ]
       }
     },
@@ -236,36 +235,6 @@
                 "type": "JwkSetSecretStore",
                 "config": {
                   "jwkUrl": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
-                  "handler": "OBClientHandler"
-                }
-              }
-            ]
-          }
-        }
-      }
-    },
-    {
-      "name": "SecureAPIGatewayTestDirectory",
-      "type": "TrustedDirectory",
-      "config": {
-        "issuer": "test-publisher",
-        "softwareStatementClaims": {
-          "organisationIdClaimName": "org_id",
-          "organisationNameClaimName": "org_name",
-          "softwareIdClaimName": "software_id",
-          "clientNameClaimName": "software_client_name",
-          "redirectUrisClaimName": "software_redirect_uris",
-          "rolesClaimName": "software_roles",
-          "jwksUriClaimName": "software_jwks_endpoint"
-        },
-        "secretsProvider": {
-          "type": "SecretsProvider",
-          "config": {
-            "stores": [
-              {
-                "type": "JwkSetSecretStore",
-                "config": {
-                  "jwkUrl": "https://&{test.directory.fqdn}/jwkms/testdirectory/jwks",
                   "handler": "OBClientHandler"
                 }
               }

--- a/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
+++ b/config/7.3.0/fapi1part2adv/ig/config/dev/config/config.json
@@ -94,9 +94,9 @@
       "name" : "ForgeRockClientHandler",
       "type" : "Chain",
       "config" : {
-        "filters" : [ 
+        "filters" : [
           "TransactionIdOutboundFilter"
-       ],
+        ],
         "handler" : "ClientHandler"
       },
       "capture" : [ "response", "request" ]
@@ -209,7 +209,8 @@
       "type": "TrustedDirectoryService",
       "config": {
         "trustedDirectories": [
-          "OpenBankingTestDirectory"
+          "OpenBankingTestDirectory",
+          "SecureAPIGatewayTestDirectory"
         ]
       }
     },
@@ -235,6 +236,36 @@
                 "type": "JwkSetSecretStore",
                 "config": {
                   "jwkUrl": "https://keystore.openbankingtest.org.uk/keystore/openbanking.jwks",
+                  "handler": "OBClientHandler"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "SecureAPIGatewayTestDirectory",
+      "type": "TrustedDirectory",
+      "config": {
+        "issuer": "test-publisher",
+        "softwareStatementClaims": {
+          "organisationIdClaimName": "org_id",
+          "organisationNameClaimName": "org_name",
+          "softwareIdClaimName": "software_id",
+          "clientNameClaimName": "software_client_name",
+          "redirectUrisClaimName": "software_redirect_uris",
+          "rolesClaimName": "software_roles",
+          "jwksUriClaimName": "software_jwks_endpoint"
+        },
+        "secretsProvider": {
+          "type": "SecretsProvider",
+          "config": {
+            "stores": [
+              {
+                "type": "JwkSetSecretStore",
+                "config": {
+                  "jwkUrl": "https://&{test.directory.fqdn}/jwkms/testdirectory/jwks",
                   "handler": "OBClientHandler"
                 }
               }

--- a/config/7.3.0/fapi1part2adv/ig/routes/routes-service/28-as-metadata.json
+++ b/config/7.3.0/fapi1part2adv/ig/routes/routes-service/28-as-metadata.json
@@ -24,7 +24,7 @@
             "file": "ASWellKnownFilter.groovy",
             "args": {
               "tokenEndpointAuthMethodsSupported": "${oauth2.tokenEndpointAuthMethodsSupported}",
-              "mtlsEndpoints": ["registration_endpoint", "token_endpoint", "pushed_authorization_request_endpoint"],
+              "mtlsEndpoints": ["registration_endpoint", "token_endpoint", "authorization_endpoint", "pushed_authorization_request_endpoint"],
               "igHost": "&{as.fqdn}",
               "mtlsHost": "&{as.mtls.fqdn}"
             }


### PR DESCRIPTION
The authorization_endpoint value in the OIDC wellknown response is currently not the mtls endpoint. This means when using tls_client_auth as the token_endpoint_auth method, no certificate is available for mTLS processing on the authorize endpoint.

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1696