### PR TITLE
1703: Create SAPIG 5.0.0

### DIFF
--- a/_infra/helm/secure-api-gateway-fapi-pep-as/Chart.yaml
+++ b/_infra/helm/secure-api-gateway-fapi-pep-as/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: fapi-pep-as
 description: FAPI PEP AS Helm chart for Kubernetes
 type: application
-version: 4.9.0
-appVersion: 4.9.0
+version: 5.0.0
+appVersion: 5.0.0


### PR DESCRIPTION
Bump helm version, release action already ran, but checked the Chart.yaml from maven artifactory and the version has been changed during release process, so this is just clean up work

Issue: https://github.com/SecureApiGateway/SecureApiGateway/issues/1703