### PR TITLE
OPENIG-9573: SAPIG 5.0.1 Release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - v5.0.1
     paths-ignore:
       - '**/README.md'
 jobs:

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <openig.version>2025.6.0-SNAPSHOT</openig.version>
+        <openig.version>2025.6.2</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
@@ -75,7 +75,7 @@
         <connection>scm:git:${project.scm.url}</connection>
         <developerConnection>scm:git:${project.scm.url}</developerConnection>
         <url>https://github.com/SecureApiGateway/secure-api-gateway-fapi-pep-as.git</url>
-        <tag>v5.0.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>com.forgerock.sapi.gateway</groupId>
     <artifactId>secure-api-gateway-fapi-pep-as</artifactId>
-    <version>5.0.0</version>
+    <version>5.0.1-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>secure-api-gateway-fapi-pep-as</name>
@@ -46,7 +46,7 @@
     </parent>
 
     <properties>
-        <openig.version>2025.6.1</openig.version>
+        <openig.version>2025.6.0-SNAPSHOT</openig.version>
         <nimbus-jose.version>9.40</nimbus-jose.version>
         <bouncy-castle.version>1.78.1</bouncy-castle.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>

--- a/secure-api-gateway-fapi-pep-as-docker/Dockerfile
+++ b/secure-api-gateway-fapi-pep-as-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig:2025.6.1-fapi
+ARG base_image=gcr.io/forgerock-io/ig/docker-build:2025.6.0-latest-postcommit-fapi
 
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this

--- a/secure-api-gateway-fapi-pep-as-docker/Dockerfile
+++ b/secure-api-gateway-fapi-pep-as-docker/Dockerfile
@@ -14,8 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig/docker-build:2025.6.0-latest-postcommit-fapi
-
+ARG base_image=gcr.io/forgerock-io/ig:2025.6.2-fapi
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this
 USER forgerock

--- a/secure-api-gateway-fapi-pep-as-docker/pom.xml
+++ b/secure-api-gateway-fapi-pep-as-docker/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-fapi-pep-as</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/secure-api-gateway-ig-extensions/pom.xml
+++ b/secure-api-gateway-ig-extensions/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.forgerock.sapi.gateway</groupId>
         <artifactId>secure-api-gateway-fapi-pep-as</artifactId>
-        <version>5.0.0</version>
+        <version>5.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Based off of V5.0.0

Updated version to `5.0.1-SNAPSHOT`
Updated openIG version to `2025.6.2`
Updated Dockerfile to `gcr.io/forgerock-io/ig:2025.6.2-fapi`

Issue: https://pingidentity.atlassian.net/browse/OPENIG-9573