### PR TITLE
OpenIG-9579: Update SAPIG pipelines to use official standalone zip and docker images

### DIFF
--- a/secure-api-gateway-fapi-pep-as-docker/Dockerfile
+++ b/secure-api-gateway-fapi-pep-as-docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-ARG base_image=gcr.io/forgerock-io/ig/docker-build:2025.9.0-latest-postcommit-fapi
+ARG base_image=gcr.io/forgerock-io/ig/docker-build:2025.9.0-latest-postcommit
 
 FROM ${base_image}
 # Switching back to forgerock user, app will run as this


### PR DESCRIPTION
Remove `-fapi` from docker image to use standard image

Issue: https://pingidentity.atlassian.net/browse/OPENIG-9579